### PR TITLE
Fix twinhead bosses' lockup, spelling and randomize Dark King attacks

### DIFF
--- a/FFMQRLib/Offsets.cs
+++ b/FFMQRLib/Offsets.cs
@@ -49,10 +49,15 @@ namespace FFMQLib
 		public const int EnemiesStatsLength = 0x0e;
 
 		// Enemies' Attacks
-		public const int EnemiesAttacksAddress = 0xC6FF; // Bank 02
-		public const int EnemiesAttacksBank = 0x02;
-		public const int EnemiesAttacksQty = 0x53;
-		public const int EnemiesAttacksLength = 0x09;
+		public const int EnemiesAttackLinksAddress = 0xC6FF; // Bank 02
+		public const int EnemiesAttackLinksBank = 0x02;
+		public const int EnemiesAttackLinksQty = 0x53;
+		public const int EnemiesAttackLinksLength = 0x09;
+
+		// Dark King Attack Links, separate from EnemiesAttacks
+		public const int DarkKingAttackLinkAddress = 0xD09E; // Bank 02
+		public const int DarkKingAttackLinkBank = 0x02;
+		public const int DarkKingAttackLinkQty = 0x0C;
 
 		// Scripts
 		public const int GameStartScript = 0x01f811;

--- a/FFMQWebAsm/Pages/Index.razor
+++ b/FFMQWebAsm/Pages/Index.razor
@@ -202,7 +202,7 @@
 </Field>
 <Field>
     <FieldLabel TextColor="TextColor.Secondary" class="fw-bold">Enemizer Attacks</FieldLabel>
-    <Tooltip Text="Shuffles enemy attacks.<br /><br />Safe: shuffle but don't add self destruct and Dark Knight attacks<br /><br />chaos: shuffle and include self destruct and Dark Knight attacks<br /><br />self-destruct: every enemy self destructs" Inline Multiline Placement="TooltipPlacement.Right">
+    <Tooltip Text="Shuffles enemy attacks.<br /><br />Safe: Shuffle but don't add self destruct and Dark King attacks<br /><br />Chaos: Shuffle and include self destruct and Dark King attacks<br /><br />Self-destruct: Every enemy self destructs" Inline Multiline Placement="TooltipPlacement.Right">
         <Icon TextColor="TextColor.Secondary" Name="IconName.QuestionCircle" IconSize=IconSize.Small /> 
     </Tooltip>
     <Select @bind-SelectedValue="@flags.EnemizerAttacks">

--- a/docs/tables.md
+++ b/docs/tables.md
@@ -38,6 +38,7 @@ Length = 9
 | 16 | Land Worm |
 | 32 | Centaur |
 | 75 | Ice Golem |
+| 76 | Twinhead Hydra |
 | 77 | Twinhead Wyvern |
 | 79 | Dark Knight Phase 1 |
 | 80 | Dark Knight Phase 2 |


### PR DESCRIPTION
Because Dark King's attack links are in a separate location, I've added some Rom Offsets. Obviously these will have to be refactored into where they're used.