### PR TITLE
Always overwrite attack pattern, fixes Skullrus Rex hang

### DIFF
--- a/FFMQRLib/Enemies.cs
+++ b/FFMQRLib/Enemies.cs
@@ -362,13 +362,13 @@ namespace FFMQLib
 
                 // Some values of Unknown1 (e.g. 0x0B) result in the third (or other) attack slot being used
                 // regardless of it being 0xFF (which is an ignored slot for most other Unknown1 values)
-                if(noOfAttacks < 3)
+                if(noOfAttacks <= 3)
                 {
                     ea.Unknown1 = 0x01;
                 }
 
                 // Similarly, most Unknown1 values do not use attack slots 5 and 6, but 0x0D and 0x0C do.
-                if(noOfAttacks > 4)
+                if(noOfAttacks >= 4)
                 {
                     ea.Unknown1 = 0x0D;
                 }

--- a/FFMQRLib/FFMQRom.cs
+++ b/FFMQRLib/FFMQRom.cs
@@ -10,7 +10,7 @@ namespace FFMQLib
 {
 	public static class Metadata
 	{
-		public static string Version = "1.2.13";
+		public static string Version = "1.2.14";
 	}
 	public partial class FFMQRom : SnesRom
 	{

--- a/docs/tables.md
+++ b/docs/tables.md
@@ -37,13 +37,19 @@ Length = 9
 | 6 | Slime |
 | 16 | Land Worm |
 | 32 | Centaur |
+| 64 | Skullrus Rex |
+| 65 | Stone Golem |
 | 75 | Ice Golem |
 | 76 | Twinhead Hydra |
 | 77 | Twinhead Wyvern |
-| 79 | Dark Knight Phase 1 |
-| 80 | Dark Knight Phase 2 |
-| 81 | Dark Knight Phase 3 |
-| 82 | Dark Knight Phase 4 |
+| 78 | Pazuzu |
+| 79 | Zuh |
+| 80 | Dark Knight Phase 1 |
+| 81 | Dark Knight Phase 2 |
+| 82 | Dark Knight Phase 3 |
+
+Phase 4 copies the stats from the previous phase (if you skip a phase, it copies whatever phase you were on)
+Dark Knight phases 2, 3 and 4 do not use the attack ids in the table, but rather use whatever is in 0x1509E with length 0x0C, phase 2 uses first 4 (maybe 6?), phase 3 uses last 6, phase 4 probably copies the previous phase as mentioned above.
 
 #### Enemy Attack Options (bytes 1 through X)
 


### PR DESCRIPTION
Skullrus Rex has attack pattern 0x0D, which requires a 4th attack slot filled. However, if the seed happened to generate 3 slots, it would not change the attack pattern. Always overwrite the attack pattern, so that the attack pattern always matches the number of slots filled.