### PR TITLE
SimpleShuffle

### DIFF
--- a/FFMQRLib/Enemies.cs
+++ b/FFMQRLib/Enemies.cs
@@ -43,12 +43,14 @@ namespace FFMQLib
     {
         [Description("Standard")]
         Normal = 0,
-        [Description("Safe")]
+        [Description("Safe Randomization")]
         Safe,
-        [Description("Chaos")]
+        [Description("Chaos Randomization")]
         Chaos,
         [Description("Self-Destruct")]
         SelfDestruct,
+        [Description("Simple Shuffle")]
+        SimpleShuffle,
     }
     public class EnemiesStats
     {
@@ -202,7 +204,7 @@ namespace FFMQLib
         public byte[] Attacks { get; set; }
         public byte Unknown2 { get; set; }
         public byte Unknown3 { get; set; }
-        private int _Id;
+        public int _Id;
         public int Id()
         {
             return _Id;
@@ -336,6 +338,22 @@ namespace FFMQLib
                     for(int i = 0; i < DarkKingAttackLinkQty; i++)
                     {
                         _darkKingAttackLinkBytes[i] = 0xC1;
+                    }
+                    break;
+                case EnemizerAttacks.SimpleShuffle:
+                    var origLinks = new List<EnemyAttackLink>(_EnemyAttackLinks);
+                    _EnemyAttackLinks.Shuffle(rng);
+                    for(int i = 0; i < _EnemyAttackLinks.Count; i++) {
+                        _EnemyAttackLinks[i]._Id = origLinks[i]._Id;
+
+                        // Some enemies require certain slots to be filled, or the game locks up
+                        foreach(var slot in _EnemyAttackLinks[i].NeedsSlotsFilled())
+                        {
+                            if(_EnemyAttackLinks[i].Attacks[slot] == 0xFF)
+                            {
+                                _EnemyAttackLinks[i].Attacks[slot] = possibleAttacks[(int)(rng.Next() % possibleAttacks.Count)];
+                            }
+                        }
                     }
                     break;
                 default:

--- a/FFMQRLib/FFMQRom.cs
+++ b/FFMQRLib/FFMQRom.cs
@@ -10,7 +10,7 @@ namespace FFMQLib
 {
 	public static class Metadata
 	{
-		public static string Version = "1.2.16";
+		public static string Version = "1.2.17";
 	}
 	public partial class FFMQRom : SnesRom
 	{

--- a/FFMQWebAsm/Pages/Index.razor
+++ b/FFMQWebAsm/Pages/Index.razor
@@ -230,7 +230,7 @@
 <Field>
     <span class="badge bg-secondary" style="width: 3rem;">beta</span>
     <FieldLabel TextColor="TextColor.Secondary" class="fw-bold">Enemizer Attacks</FieldLabel>
-    <Tooltip Text="Shuffles enemy attacks.<br /><br />Safe: Shuffle but don't add self destruct and Dark King attacks<br /><br />Chaos: Shuffle and include self destruct and Dark King attacks<br /><br />Self-destruct: Every enemy self destructs" Inline Multiline Placement="TooltipPlacement.Right">
+    <Tooltip Text="Shuffles enemy attacks.<br /><br />Standard: No shuffle.<br /><br />Safe Randomization: Randomize every attack but leave out self-destruct and Dark King attacks<br /><br />Chaos Randomization: Randomize and include self destruct and Dark King attacks<br /><br />Self-destruct: Every enemy self destructs<br /><br />Simple Shuffle: Instead of randomizing, shuffle one monsters attacks to another. Dark King is left vanilla." Inline Multiline Placement="TooltipPlacement.Right">
         <Icon TextColor="TextColor.Secondary" Name="IconName.QuestionCircle" IconSize=IconSize.Small /> 
     </Tooltip>
     <Select @bind-SelectedValue="@flags.EnemizerAttacks">


### PR DESCRIPTION
Add a shuffle option to the attack randomizer which only shuffles enemies (leaving DK vanilla) instead of randomizing their attacks.